### PR TITLE
Updated source of PKGBUILD i3-git.

### DIFF
--- a/i3-git/PKGBUILD
+++ b/i3-git/PKGBUILD
@@ -25,7 +25,7 @@ optdepends=('rxvt-unicode: The terminal emulator used in the default config.'
             'perl-json-xs: For i3-save-tree'
             'perl-anyevent-i3: For i3-save-tree')
 options=('docs' '!strip')
-source=('git://code.i3wm.org/i3#branch=next')
+source=('https://github.com/i3/i3.git')
 sha1sums=('SKIP')
 
 _gitname='i3'

--- a/i3-git/PKGBUILD
+++ b/i3-git/PKGBUILD
@@ -25,7 +25,7 @@ optdepends=('rxvt-unicode: The terminal emulator used in the default config.'
             'perl-json-xs: For i3-save-tree'
             'perl-anyevent-i3: For i3-save-tree')
 options=('docs' '!strip')
-source=('https://github.com/i3/i3.git')
+source=('git://github.com/i3/i3.git')
 sha1sums=('SKIP')
 
 _gitname='i3'


### PR DESCRIPTION
The next branch seems to be the default branch of the i3 repository so git://github.com/i3/i3.git should be ok.

I didn't update the package version though.
